### PR TITLE
use withDefault from Maybe module

### DIFF
--- a/dapp/client/App.elm
+++ b/dapp/client/App.elm
@@ -3,9 +3,7 @@ port module App exposing (..)
 import Html exposing (Html, button, div, text, program)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
-
-
--- Types
+import Maybe exposing (withDefault)
 
 
 type alias Address =
@@ -17,7 +15,9 @@ type alias Amount =
 
 
 type alias Model =
-    { address : Maybe Address, eth : Amount }
+    { address : Maybe Address
+    , eth : Amount
+    }
 
 
 type Message
@@ -86,38 +86,29 @@ subscriptions model =
 -- VIEW
 
 
-renderModel : Model -> Html Message
-renderModel model =
+view : Model -> Html Message
+view model =
     div [ class "wallet" ]
         [ div [ class "address" ]
             [ div [ class "label" ] [ text "Address" ]
             , div []
                 [ button [ class "fa fa-refresh", onClick RefreshAddress ] []
-                , div [ class "value" ] [ text (maybeString model.address) ]
+                , div [ class "value" ] [ text <| showAddress model.address ]
                 ]
             ]
         ]
 
 
-maybeString : Maybe String -> String
-maybeString x =
-    case x of
-        Nothing ->
-            "No Address Available"
-
-        Just y ->
-            y
-
-
-
--- MAIN
+showAddress : Maybe Address -> String
+showAddress x =
+    withDefault "No Address Available" x
 
 
 main : Program Never Model Message
 main =
     program
         { init = ( { address = Nothing, eth = 0 }, requestAddress () )
-        , view = renderModel
+        , view = view
         , update = update
         , subscriptions = subscriptions
         }


### PR DESCRIPTION
The [Maybe module](http://package.elm-lang.org/packages/elm-lang/core/latest/Maybe) contains `withDefault` that does what `maybeString` was doing. Renamed that function to `showAddress` to be more explicit.

Uses [backward function application (<|)](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#%3C|) to avoid parenthesis. I'm not sure if I always like that, but wanted to show an example. 

I think simply using `view` as the name of the view function is better because I know what it is. As the app grows there will probably be multiple view helper functions that render part of the model, so having the main one named `view` is a good convention.